### PR TITLE
Add closed ceiling collision for space station

### DIFF
--- a/descriptions/furniture/space_station/space_station.urdf.xacro
+++ b/descriptions/furniture/space_station/space_station.urdf.xacro
@@ -12,16 +12,26 @@
 
     <link name="space_station">
       <visual>
-          <origin xyz="0 0 0" rpy="0 0 0"/>
-          <geometry>
-              <mesh filename="package://picknik_accessories/descriptions/furniture/space_station/space_booth.dae"/>
-          </geometry>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://picknik_accessories/descriptions/furniture/space_station/space_booth.dae"/>
+        </geometry>
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
-          <geometry>
-              <mesh filename="package://picknik_accessories/descriptions/furniture/space_station/space_booth.dae"/>
-          </geometry>
+        <geometry>
+          <mesh filename="package://picknik_accessories/descriptions/furniture/space_station/space_booth.dae"/>
+        </geometry>
+      </collision>
+      <!-- box collision for the ceiling so that the robot does not try to plan into the open gaps of the ceiling -->
+      <collision>
+        <origin xyz="0 0 2.325" rpy="0 0 0"/>
+        <geometry>
+          <box size="3 2.1 0.05"/>
+        </geometry>
+        <material>
+          <color rgba="1.0 0 0 1"/>
+        </material>
       </collision>
       <inertial>
         <origin xyz="0.225 0.14 0.345" rpy="0 0 0"/>

--- a/descriptions/furniture/space_station/space_station.urdf.xacro
+++ b/descriptions/furniture/space_station/space_station.urdf.xacro
@@ -25,9 +25,9 @@
       </collision>
       <!-- box collision for the ceiling so that the robot does not try to plan into the open gaps of the ceiling -->
       <collision>
-        <origin xyz="0 0 2.325" rpy="0 0 0"/>
+        <origin xyz="0 0 2.3" rpy="0 0 0"/>
         <geometry>
-          <box size="3 2.1 0.05"/>
+          <box size="3 2.1 0.08"/>
         </geometry>
         <material>
           <color rgba="1.0 0 0 1"/>


### PR DESCRIPTION
Part of https://github.com/PickNikRobotics/moveit_studio/issues/5754

Adds a box collision to the space station ceiling so that the robot does not try to plan through the ceiling openings.

Here's how the ceiling looks:

![open_ceiling](https://github.com/PickNikRobotics/picknik_accessories/assets/42042756/cdc5dcc1-c768-4f73-a645-350279223696)

Here's the collision to account for this (ignore the robot on rail and its collisions; this was just the environment I was testing in :slightly_smiling_face:):

![Screenshot from 2024-01-11 17-47-17](https://github.com/PickNikRobotics/picknik_accessories/assets/42042756/da3567e6-e41d-48c7-bc3d-759715159f54)
