### PR TITLE
Update to 4.0.0 and clean up repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
       - id: check-symlinks
       - id: check-yaml
         args: ["--unsafe"] # Fixes errors parsing custom YAML constructors like ur_description's !degrees
-        exclude: 'src/moveit_studio_web/pnpm-lock.yaml'
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -61,7 +60,6 @@ repos:
           ]
         types: [text]
         files: \.(yml|yaml)$
-        exclude: 'src/moveit_studio_web/pnpm-lock.yaml'
 
   - repo: https://github.com/tcort/markdown-link-check
     rev: v3.10.3

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2024 PickNik Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# PickNik Accessories
+
+URDFs and geometry for common objects and attachments.

--- a/blender/README.md
+++ b/blender/README.md
@@ -1,3 +1,3 @@
 Folder for maintaining Blender source files for various scene descriptions.
 
-This folder should NOT be included in this package's build, as these files should not be included in MoveIt Studio binary images.
+This folder should NOT be included in this package's build, as these files should not be included in binary Docker images.

--- a/descriptions/simulation_worlds/warehouse.sdf
+++ b/descriptions/simulation_worlds/warehouse.sdf
@@ -1,5 +1,5 @@
 <sdf version="1.6">
-  <world name="moveit_studio">
+  <world name="warehouse_simple">
     <!-- Sim must be faster than the controller rate or there will be an error -->
     <physics name="sim_time" type="ignored">
       <max_step_size>0.005</max_step_size>

--- a/descriptions/simulation_worlds/warehouse_simple.sdf
+++ b/descriptions/simulation_worlds/warehouse_simple.sdf
@@ -1,5 +1,5 @@
 <sdf version="1.6">
-  <world name="moveit_studio">
+  <world name="warehouse">
     <!-- Sim must be faster than the controller rate or there will be an error -->
     <physics name="sim_time" type="ignored">
       <max_step_size>0.005</max_step_size>

--- a/package.xml
+++ b/package.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>picknik_accessories</name>
-  <version>2.10.0</version>
+  <version>4.0.0</version>
   <description>URDFs and geometry for common objects and attachments.</description>
   <maintainer email="joseph.schornak@picknik.ai">Joseph Schornak</maintainer>
-  <license>Proprietary</license>
+  <license>BSD 3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
This PR bumps the package version to 4.0.0 and also updates the license to a permissive one, as it's a public package.

Other small cleanups as well.