### PR TITLE
set use_mesh=false by default in the realsense macro

### DIFF
--- a/descriptions/sensors/realsense_d415.urdf.xacro
+++ b/descriptions/sensors/realsense_d415.urdf.xacro
@@ -12,7 +12,7 @@ aluminum peripheral evaluation case.
   <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
   <xacro:include filename="$(find realsense2_description)/urdf/_usb_plug.urdf.xacro" />
 
-  <xacro:macro name="realsense_d415" params="parent *origin name:=d415 use_nominal_extrinsics:=true add_plug:=false use_mesh:=true gazebo_camera_fps:=6">
+  <xacro:macro name="realsense_d415" params="parent *origin name:=d415 use_nominal_extrinsics:=true add_plug:=false use_mesh:=false gazebo_camera_fps:=6">
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
     <!-- The following values are approximate, and the camera node


### PR DESCRIPTION
First part towards https://github.com/PickNikRobotics/moveit_pro/issues/10823
This will disable the Realsense visual mesh on configs where we use this xacro: mostly the kinova configs.
A separate PR will update the `lab_sim` URDF, which doesn't use this xacro