### PR TITLE
Add factory_sim assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 project(picknik_accessories)
 
 find_package(ament_cmake REQUIRED)
+find_package(fanuc_lrmate200id_support REQUIRED)
 
 install(
   DIRECTORY
@@ -11,6 +12,21 @@ install(
   DESTINATION
     share/${PROJECT_NAME}
 )
+
+# Mujoco models in this package use relative paths to assets such as meshes and textures
+# To simplify building relative paths to assets in other packages, we will copy those assets into this project's file structure
+
+# Paths we will copy from - the assets we want to easily reference in our Mujoco model
+set(FANUC_LRMATE200ID_SUPPORT_PATH "${fanuc_lrmate200id_support_DIR}/../meshes")
+
+# Path we will copy to - the folder where the other Mujoco assets are located
+set(DEST_DIR "share/${PROJECT_NAME}/mujoco_assets/")
+
+# Copy all contents into the installed description folder
+install(DIRECTORY "${FANUC_LRMATE200ID_SUPPORT_PATH}"
+        DESTINATION "${DEST_DIR}"
+        FILES_MATCHING PATTERN "*")
+
 # TODO: is this lint process hanging somehow?
 # if(BUILD_TESTING)
 # find_package(ament_lint_auto REQUIRED)

--- a/mujoco_assets/assets/bowl.stl
+++ b/mujoco_assets/assets/bowl.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27f5de6bb4e388f6fe2cbfa8a24707f58d2cd3292d6c2e04ba701e38b289d7a4
+size 500084

--- a/mujoco_assets/assets/bowl_concave_hemisphere.stl
+++ b/mujoco_assets/assets/bowl_concave_hemisphere.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f79d1420324dcb1a76ea27d00abd73b40865fbca0fceed0b51de07e93129207
+size 508884

--- a/mujoco_assets/assets/bowl_convex_hemisphere.stl
+++ b/mujoco_assets/assets/bowl_convex_hemisphere.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9918bd200dc33e62c818c8e20fd312a9b0c7b106c2905781a1262c36e2f18916
+size 508884

--- a/mujoco_assets/assets/lrmate200id/collision/base_link.stl
+++ b/mujoco_assets/assets/lrmate200id/collision/base_link.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7d6f17f3012445ab8bacd18885db9437646b131253b92ac7f880dcc03267642
-size 120284

--- a/mujoco_assets/assets/lrmate200id/collision/link_1.stl
+++ b/mujoco_assets/assets/lrmate200id/collision/link_1.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:353992336fd3daaca21d8adc28bcc5b4e64052df262f8e40738c1b147bc44db3
-size 228884

--- a/mujoco_assets/assets/lrmate200id/collision/link_2.stl
+++ b/mujoco_assets/assets/lrmate200id/collision/link_2.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae7664e6c422d33f0bd2563f8e9f2a25281b1c992e102c1c4bffd0e469491b27
-size 99884

--- a/mujoco_assets/assets/lrmate200id/collision/link_3.stl
+++ b/mujoco_assets/assets/lrmate200id/collision/link_3.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc1a5d033ea34ca5fdc1b1305eec3993fa63afb715e69e9ee934315de2fa07ed
-size 292584

--- a/mujoco_assets/assets/lrmate200id/collision/link_4.stl
+++ b/mujoco_assets/assets/lrmate200id/collision/link_4.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43b004eec473fd1c9e6bd92901004fd661bfa2b3bfb7f412206c51dc0f81c354
-size 179684

--- a/mujoco_assets/assets/lrmate200id/collision/link_5.stl
+++ b/mujoco_assets/assets/lrmate200id/collision/link_5.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ece3a0851d58a1bbf50a917b80659ad6a3b90083f7def9db6fd230514b0dc5f
-size 162384

--- a/mujoco_assets/assets/lrmate200id/collision/link_6.stl
+++ b/mujoco_assets/assets/lrmate200id/collision/link_6.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77b9b50f1c2edfd5384aa88b2371807640e638e5d2b597b5c7ecffe9a897a720
-size 19584

--- a/mujoco_assets/assets/lrmate200id/visual/base_link.stl
+++ b/mujoco_assets/assets/lrmate200id/visual/base_link.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7d6f17f3012445ab8bacd18885db9437646b131253b92ac7f880dcc03267642
-size 120284

--- a/mujoco_assets/assets/lrmate200id/visual/link_1.stl
+++ b/mujoco_assets/assets/lrmate200id/visual/link_1.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:353992336fd3daaca21d8adc28bcc5b4e64052df262f8e40738c1b147bc44db3
-size 228884

--- a/mujoco_assets/assets/lrmate200id/visual/link_2.stl
+++ b/mujoco_assets/assets/lrmate200id/visual/link_2.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dee03cd4b0ad3a98f3d1afc06356f4cf03f087d86f987cba0dcf33ae4e59b725
-size 253784

--- a/mujoco_assets/assets/lrmate200id/visual/link_3.stl
+++ b/mujoco_assets/assets/lrmate200id/visual/link_3.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc1a5d033ea34ca5fdc1b1305eec3993fa63afb715e69e9ee934315de2fa07ed
-size 292584

--- a/mujoco_assets/assets/lrmate200id/visual/link_4.stl
+++ b/mujoco_assets/assets/lrmate200id/visual/link_4.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43b004eec473fd1c9e6bd92901004fd661bfa2b3bfb7f412206c51dc0f81c354
-size 179684

--- a/mujoco_assets/assets/lrmate200id/visual/link_5.stl
+++ b/mujoco_assets/assets/lrmate200id/visual/link_5.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ece3a0851d58a1bbf50a917b80659ad6a3b90083f7def9db6fd230514b0dc5f
-size 162384

--- a/mujoco_assets/assets/lrmate200id/visual/link_6.stl
+++ b/mujoco_assets/assets/lrmate200id/visual/link_6.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77b9b50f1c2edfd5384aa88b2371807640e638e5d2b597b5c7ecffe9a897a720
-size 19584

--- a/mujoco_assets/lrmate200id/lrmate200id_globals.xml
+++ b/mujoco_assets/lrmate200id/lrmate200id_globals.xml
@@ -23,41 +23,41 @@
     <material name="fanuc_gray28" rgba="0.28 0.28 0.28 1.0" />
     <material name="fanuc_black" rgba="0.0 0.0 0.0 1.0" />
     <!-- Define meshes with appropriate scaling -->
-    <mesh name="base_link" file="assets/lrmate200id/visual/base_link.stl" />
-    <mesh name="link_1" file="assets/lrmate200id/visual/link_1.stl" />
-    <mesh name="link_2" file="assets/lrmate200id/visual/link_2.stl" />
-    <mesh name="link_3" file="assets/lrmate200id/visual/link_3.stl" />
-    <mesh name="link_4" file="assets/lrmate200id/visual/link_4.stl" />
-    <mesh name="link_5" file="assets/lrmate200id/visual/link_5.stl" />
-    <mesh name="link_6" file="assets/lrmate200id/visual/link_6.stl" />
+    <mesh name="base_link" file="meshes/lrmate200id/visual/base_link.stl" />
+    <mesh name="link_1" file="meshes/lrmate200id/visual/link_1.stl" />
+    <mesh name="link_2" file="meshes/lrmate200id/visual/link_2.stl" />
+    <mesh name="link_3" file="meshes/lrmate200id/visual/link_3.stl" />
+    <mesh name="link_4" file="meshes/lrmate200id/visual/link_4.stl" />
+    <mesh name="link_5" file="meshes/lrmate200id/visual/link_5.stl" />
+    <mesh name="link_6" file="meshes/lrmate200id/visual/link_6.stl" />
     <!-- Collision meshes -->
     <mesh
       name="base_link_collision"
-      file="assets/lrmate200id/collision/base_link.stl"
+      file="meshes/lrmate200id/collision/base_link.stl"
     />
     <mesh
       name="link_1_collision"
-      file="assets/lrmate200id/collision/link_1.stl"
+      file="meshes/lrmate200id/collision/link_1.stl"
     />
     <mesh
       name="link_2_collision"
-      file="assets/lrmate200id/collision/link_2.stl"
+      file="meshes/lrmate200id/collision/link_2.stl"
     />
     <mesh
       name="link_3_collision"
-      file="assets/lrmate200id/collision/link_3.stl"
+      file="meshes/lrmate200id/collision/link_3.stl"
     />
     <mesh
       name="link_4_collision"
-      file="assets/lrmate200id/collision/link_4.stl"
+      file="meshes/lrmate200id/collision/link_4.stl"
     />
     <mesh
       name="link_5_collision"
-      file="assets/lrmate200id/collision/link_5.stl"
+      file="meshes/lrmate200id/collision/link_5.stl"
     />
     <mesh
       name="link_6_collision"
-      file="assets/lrmate200id/collision/link_6.stl"
+      file="meshes/lrmate200id/collision/link_6.stl"
     />
   </asset>
 

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>fanuc_lrmate200id_support</depend>
+
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>robotiq_description</exec_depend>
   <exec_depend>ur_description</exec_depend>


### PR DESCRIPTION
Adds bowl asset and normal oriented hemispheres to use for ICP registration of bowls.

![Screenshot from 2025-03-05 08-56-43](https://github.com/user-attachments/assets/d5e5b041-5164-46b0-ae3f-a306080a068b)
