### PR TITLE
Updated bottle shape

### DIFF
--- a/mujoco_assets/lab_desk/desk.xml
+++ b/mujoco_assets/lab_desk/desk.xml
@@ -157,7 +157,7 @@
       conaffinity="0"
       group="2"
     />
-    <geom type="cylinder" size="0.014 0.04" pos="0 0 0.06" class="collision" group="4"/>
+    <geom type="cylinder" size="0.014 0.045" pos="0 0 0.06" class="collision" group="4"/>
     <geom type="mesh" class="collision" mesh="flask-cone" group="4"/>
     <joint type="free" damping="1" />
   </body>
@@ -176,15 +176,13 @@
       contype="0"
       conaffinity="0"
       group="2"
-    />
-    <geom
-      type="mesh"
-      class="collision"
-      mesh="bottle"
-      group="4"
-      solref="0.01 1.1"
-      friction="0.5"
-    />
+    /> 
+    <geom type="box" size="0.0200 0.0200 0.0285" class="collision" group="4" pos="0 0 0.0285"
+    solref="0.01 1.1"
+    friction="0.5"/>
+    <geom type="cylinder" size="0.0145 0.0284" pos="0 0 0.057" class="collision" group="4"
+    solref="0.01 1.1"
+    friction="0.5"/>
     <joint type="free" damping="1" />
   </body>
   <body name="bottle_2" pos="-0.1 0.85 0.473807" euler="0 0 10">
@@ -196,14 +194,12 @@
       conaffinity="0"
       group="2"
     />
-    <geom
-      type="mesh"
-      class="collision"
-      mesh="bottle"
-      group="4"
-      solref="0.01 1.1"
-      friction="0.5"
-    />
+    <geom type="box" size="0.0200 0.0200 0.0285" class="collision" group="4" pos="0 0 0.0285"
+    solref="0.01 1.1"
+    friction="0.5"/>
+    <geom type="cylinder" size="0.0145 0.0284" pos="0 0 0.057" class="collision" group="4"
+    solref="0.01 1.1"
+    friction="0.5"/>
     <joint type="free" damping="1" />
   </body>
   <body name="bottle_3" pos="0.05 0.85 0.473807" euler="0 0 -30">
@@ -215,14 +211,12 @@
       conaffinity="0"
       group="2"
     />
-    <geom
-      type="mesh"
-      class="collision"
-      mesh="bottle"
-      group="4"
-      solref="0.01 1.1"
-      friction="0.5"
-    />
+    <geom type="box" size="0.0200 0.0200 0.0285" class="collision" group="4" pos="0 0 0.0285"
+    solref="0.01 1.1"
+    friction="0.5"/>
+    <geom type="cylinder" size="0.0145 0.0284" pos="0 0 0.057" class="collision" group="4"
+    solref="0.01 1.1"
+    friction="0.5"/>
     <joint type="free" damping="1" />
   </body>
 </lab_desk>


### PR DESCRIPTION
The previous shape would not be graspable at the cap:
![image_480](https://github.com/user-attachments/assets/fb1a7d62-56cf-44f9-8925-4a320e17d8f5)
Now it is:
![image](https://github.com/user-attachments/assets/88708cd6-c98c-4fba-a450-cf61904ba98b)
