### PR TITLE
Change glass material so that depth cameras detect it

### DIFF
--- a/mujoco_assets/lab_desk/desk_globals.xml
+++ b/mujoco_assets/lab_desk/desk_globals.xml
@@ -75,7 +75,7 @@
       specular="0.5"
       shininess="0.5"
     />
-    <material name="glass" rgba="0.659 0.800 0.843 0.3" />
+    <material name="glass" rgba="0.659 0.800 0.843 1" />
     <material
       name="stirrer"
       texture="stirrer_texture"


### PR DESCRIPTION
Change glass material to a solid from the lidar perspective, if the alpha is less than 1 ros_mujoco will raytrace the depth sensor through the object instead of the correct depthimagae (it mimics real life lidar behavior with glass)
Before
<img width="2543" height="955" alt="image" src="https://github.com/user-attachments/assets/f85eccff-592a-469f-8a2d-ae7b0ca3adbd" />

After
<img width="2543" height="955" alt="image" src="https://github.com/user-attachments/assets/c4b05f59-4380-440b-b8ad-c58eff17782b" />
