### PR TITLE
Add bottle.stl from bottle.obj export for ICP fit

### DIFF
--- a/mujoco_assets/assets/bottle.stl
+++ b/mujoco_assets/assets/bottle.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0e1c614edf4c0ad92e9e73af54fa79f0f7d356a4c6ba4c51d04237ed09ca5e4
+size 264084


### PR DESCRIPTION
## Summary

- Add `mujoco_assets/assets/bottle.stl` alongside the existing `bottle.obj`, exported from the same source mesh with the local frame preserved (base at z=0, bbox 40x40x83 mm).
- `LoadPointCloudFromFile` only supports `.pcd` / `.stl`, so the STL is required to let behaviors in `lab_sim` fit the bottle geometry via ICP.
- No CMake change needed — the existing install rule covers the whole `mujoco_assets/` directory.

## Context

Part of https://github.com/PickNikRobotics/moveit_pro/issues/18205 (Pick All Pill Bottles rework). The downstream objective is getting two perception changes that together fix the regression where bottles aren't picked:

- **Grasp estimation:** swap the learned L2G estimator for ICP registration — this STL is what ICP aligns against.
- **Segmentation:** swap CLIPSeg text-prompt masks for SAM3 exemplar-image-prompted masks, so wrist-camera masks track the real pill bottles rather than the decoy colored bottles in the scene.

The SAM3 switch doesn't require anything from this PR; it's listed here only so a reviewer sees the full perception picture. The `moveit_pro_example_ws` PR containing both changes will land separately once the 18205 branch is squashed — this STL-only PR can merge independently.

## Test plan

- [ ] `colcon build --packages-select picknik_accessories` succeeds in the dev container.
- [ ] `install/picknik_accessories/share/picknik_accessories/mujoco_assets/assets/bottle.stl` is present after build.
- [ ] Sanity load via `LoadPointCloudFromFile` with `package_name="picknik_accessories" file_path="mujoco_assets/assets/bottle.stl"` — covered downstream in the example_ws PR.