### PR TITLE
Fix: Make lab_sim burner pushable under realistic gripper force

### DIFF
--- a/mujoco_assets/lab_desk/desk.xml
+++ b/mujoco_assets/lab_desk/desk.xml
@@ -132,13 +132,26 @@
     <joint type="free" damping="1" />
   </body>
   <body name="stirrer" pos="0.605 0.761 0.473827" euler="0 0 0">
-    <freejoint/>
+    <joint type="free" damping="1"/>
+    <!-- Explicit inertial keeps the burner light enough to be pushed by the gripper.
+         Without this, MuJoCo auto-infers ~9.7 kg from the 0.2x0.4x0.074 m collision box
+         at default density 1000 kg/m^3, and static friction (per MAX-rule combine
+         with the desk's default friction=1.0) pins it under any vertical-dominant
+         gripper push. priority="1" on the collision geom below makes the burner's
+         lower friction override the desk's, so the burner can actually slide.
+         The diaginertia is intentionally non-homogeneous: a real stirrer's mass
+         is biased toward the base (motor + heavy stand) under a thin top plate,
+         so xx/yy are symmetric and well below the homogeneous-box values
+         (~0.0207, ~0.00569, ~0.025 for 1.5 kg, 0.2x0.4x0.074 m). Do not
+         regenerate these from the collision box extents. -->
+    <inertial pos="0 0 0.02" mass="1.5" diaginertia="0.008 0.008 0.012"/>
     <geom
       material="stirrer"
       mesh="stirrer"
       class="visual"
       contype="0"
       conaffinity="0"
+      mass="0"
       group="2"
     />
     <geom
@@ -147,6 +160,8 @@
       pos="0 0 0"
       size="0.1 0.2 0.037"
       group="4"
+      friction="0.3 0.005 0.0001"
+      priority="1"
     />
   </body>
   <body name="test_tubes_stand" pos="0.3 0.85 0.472476" euler="0 0 0">


### PR DESCRIPTION
## Root cause

The `stirrer` body in `mujoco_assets/lab_desk/desk.xml` had no `<inertial>`
block — MuJoCo auto-inferred ~9.7 kg from the 0.2×0.4×0.074 m collision box
at default density 1000 kg/m³. Combined with MuJoCo's MAX-rule friction-combine
and the desk's default friction=1.0, the burner-on-desk friction limit (~95 N
from self-weight alone) exceeded any horizontal force a realistic gripper push
produces.

Tutorial 1's `Push Button` Objective at `force_threshold=1000` visibly contacts
the burner top but the burner stays pinned, matching
PickNikRobotics/moveit_pro#19151.

## Fix

On the `stirrer` body:
- Explicit `<inertial mass="1.5">` overrides the 9.7 kg auto-inferred mass.
- `friction="0.3"` + `priority="1"` on the collision geom. priority=1 wins
  the contact-pair friction combine over the desk's default 1.0; without it,
  the MAX rule keeps 1.0 and the burner stays pinned even with low burner
  friction.

## Verification

Reverted `desk.xml` on this branch, restarted the lab_sim agent, re-ran
`Push Button` at `force_threshold=1000` — burner stayed pinned (matching the
bug). Re-applied the fix — burner slides ~26 cm under the gripper's push.

Related: PickNikRobotics/moveit_pro#19151 — will be closed by the
`moveit_pro_example_ws` submodule-bump PR once that lands.